### PR TITLE
feat: Task 8.1/8.2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+test
+node_modules
+.git
+.gitignore
+.eslintrc.js
+npm-debug.log
+.prettierrc
+Dockerfile*
+README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+dist
 test
 node_modules
 .git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:15.3.0-alpine3.10 as build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --also=dev 
+
+# build
+COPY . .
+RUN npm run build
+
+#2
+FROM node:15.3.0-alpine3.10 
+
+ARG NODE_ENV=production
+ENV NODE_ENV $NODE_ENV
+
+COPY --from=build /app/package*.json ./
+RUN npm ci --only production && npm install pm2 -g
+
+COPY --from=build ./app/dist /dist/
+
+USER node
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["pm2-runtime", "./dist/main.js"] 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,26 @@
+# preparing
 FROM node:15.3.0-alpine3.10 as build
 
 WORKDIR /app
 
-COPY package*.json ./
-RUN npm ci --also=dev 
+COPY src \
+     package*.json \
+     nest-cli.json \
+     tsconfig*.json ./
 
-# build
-COPY . .
-RUN npm run build
+RUN npm ci --also=dev
+RUN npm run build 
+RUN npm prune --production
 
-#2
+# go
 FROM node:15.3.0-alpine3.10 
 
 ARG NODE_ENV=production
 ENV NODE_ENV $NODE_ENV
 
-COPY --from=build /app/package*.json ./
-RUN npm ci --only production && npm install pm2 -g
+RUN npm install pm2 -g
 
-COPY --from=build ./app/dist /dist/
+COPY --from=build ./app .
 
 USER node
 ENV PORT=8080

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,16 +6,17 @@ import { AppModule } from './app.module';
 
 const port = process.env.PORT || 4000;
 
-async function bootstrap() {
+const bootstrap = async () => {
   const app = await NestFactory.create(AppModule);
 
   app.enableCors({
-    origin: (req, callback) => callback(null, true),
+    origin: '*',
   });
   app.use(helmet());
 
   await app.listen(port);
 }
+
 bootstrap().then(() => {
   console.log('App is running on %s port', port);
 });


### PR DESCRIPTION
[Task8 details](https://github.com/rolling-scopes-school/nodejs-aws-tasks/blob/main/task8-docker-elastic-beanstalk/task.md)

`AWS Beanstalk Endpoint:` http://shurygindv-rs-cart-api-dev.eu-west-1.elasticbeanstalk.com/api/profile/cart
`Frontend Integration`: http://d7cnyur3qbvu2.cloudfront.net/cart

`Frontend changes (PR)` : https://github.com/shurygindv/nodejs-aws-fe/pull/6


**.dockerignore explanation**
`test`
`node_modules`
`.git`
`.gitignore`
`.eslintrc.js`
`npm-debug.log`
`.prettierrc`
`Dockerfile*`
`README.md`

The above files don't participate in the docker steps (`npm i` / `npm run build` processes) therefore we can exclude these from sending to the daemon server, why should we spend time on pack unused files/image size?

**What is done:**
1 - Dockerfile is prepared, image is building. Image size is minimised to be less than 500 MB.
2 - Dockerfile is optimized. Files that change more often and commands that depend on them should be included later, files and commands that change less should be at the top.
3 - Folders are added to .dockerignore, with explanations. At least 2 big directories should be excluded from build context. Elastic Beanstalk application is initialized.
4 - Environment is created and the app is deployed to the AWS cloud. You must provide a link to your GitHub repo with Cart API service or PR with created Dockerfile and related configurations.
5 - FE application is updated with Cart API endpoint. You must provide a PR with updates in your FE repository and OPTIONALLY link to deployed front-end app which makes proper API calls to your Cart service.

